### PR TITLE
Fixed bug in string parser

### DIFF
--- a/fixtures/TestStringParser.golden
+++ b/fixtures/TestStringParser.golden
@@ -5,5 +5,7 @@
  "Field3": "hello\u0000world",
  "Field4": "hel",
  "Field5": "hel",
- "Field6": "hello"
+ "Field6": "hello",
+ "Field7": "",
+ "Field8": "hello"
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -174,7 +174,19 @@ func TestStringParser(t *testing.T) {
      ["Field6", 31, "String", {
         "term_exp": "x=> '\u0000world'",
         "encoding": "utf16"
-      }]
+      }],
+
+     # A length of zero is a valid length for the empty string.
+     ["Field7", 31, "String", {
+        "length": "x=>0",
+        "encoding": "utf16"
+     }],
+
+     # When length is not specified, we default to 1kb but still honor the term.
+     ["Field8", 31, "String", {
+        "encoding": "utf16"
+     }]
+
   ]]
 ]
 `


### PR DESCRIPTION
A length of 0 is a valid length for empty string. Previously this
created a string of 1kb as 0 was taken to be the default length.