### PR TITLE
Added reference syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,145 @@ using the following options.
 3. length, max_length: The length of the string - if not specified we
    use the terminator to find the end of the string. This can also be
    a lambda to derive the length from another field.
+
+
+### References
+
+When dereferencing a struct member we receive the basic type contained
+in the struct.
+
+Consider the following struct:
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Field2", 0, Value, {
+         value: "x=>x.Field1 + 1"
+     }]
+  ]]
+]
+```
+
+In VQL, accessing the field will produce a uint8 type, so `Field2`
+will be calculated by adding 1 to the uint8 content of Field1.
+
+While this makes it easy and intuitive to use, sometimes we need to
+calculate some metadata over the struct field instead of it's literal
+value. For example metadata such as its starting offset, ending offset
+etc.
+
+Suppose we wanted to add another field, immediately following Field1:
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Next", "x=>x.Field1.EndOf", "uint16"],
+  ]]
+]
+```
+
+This is not going to work, because `x.Field1` is a `uint8` integer
+type and it does not have an `EndOf` method.
+
+This is where references come in. We can obtain a struct field
+reference by using the @ character when accessing the field. A
+reference is a wrapper around the field which provides metadata about
+it.
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Next", "x=>x.`@Field1`.RelEndOf", "uint16"],
+  ]]
+]
+```
+
+Note that the field name must be enclosed in backticks for VQL to
+identify the @ as part of the field name.
+
+Accessing a struct field with a name begining with @ will return a
+reference to the field instead of the field itself.
+
+The reference has many useful methods:
+
+- *SizeOf*, *Size*: These return the size of the field in bytes.
+- *StartOf*, *Start*, *OffsetOf*: These return the byte offset of the
+  beginning of the field.
+
+  NOTE that this offset is absolute - i.e. this offset will be
+  relative to the beginning of the file.
+
+- *RelOffset*: The relative offset of the field within the struct.
+
+  In the following, the Next and Next2 fields are equivalent:
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Next", "x=>x.`@Field1`.StartOf + 4 - x.OffsetOf", "uint16"],
+     ["Next2", "x=>x.`@Field1`.RelOffset + 4", "uint16"],
+  ]]
+]
+```
+
+- *EndOf*, *End*: These return the end of the field in absolute bytes,
+  relative to the file.
+
+  In the following, the Next and Next2 fields are equivalent and are
+  both located directly after `Field1`:
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Next", "x=>x.`@Field1`.EndOf - x.OffsetOf", "uint16"],
+     ["Next2", "x=>x.`@Field1`.RelOffset + x.`@Field1`.SizeOf", "uint16"],
+  ]]
+]
+```
+
+- *RelEndOf*: Like *EndOf* but relative to the start of the struct.
+
+  In particular notice that the profile struct syntax requires
+  specifying the offset of a field relative to the struct. Therefore
+  this field is especially useful to specify the field should be
+  located immediately after the previous field.
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Next", "x=>x.`@Field1`.RelEndOf", "uint16"],
+  ]]
+]
+```
+
+  This also works for fields with variable size. For example consider
+  a null terminated string followed immediately with an integer.
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 0, String],
+     ["Next", "x=>x.`@Field1`.RelEndOf", "uint32"],
+  ]]
+]
+```
+
+- *Value*: It is possible to dereference the reference to obtain the
+  real value.
+
+```json
+[
+  ["TestStruct", 0, [
+     ["Field1", 2, "uint8"],
+     ["Field2", 0, Value, {
+         value: "x=>x.`@Field1`.Value + 1"
+     }]
+  ]]
+]
+```

--- a/fixtures/TestStructParser.golden
+++ b/fixtures/TestStructParser.golden
@@ -1,20 +1,36 @@
 {
- "Field1": 3,
+ "Field1": 5,
  "Field2": {
-  "SecondField1": 7
+  "SecondField1": 9
  },
+ "StringField": "hello",
  "X": {
-  "Field1": 3,
+  "Field1": 5,
   "Field2": {
-   "SecondField1": 7
+   "SecondField1": 9
   },
-  "Field3": 578437695752307201,
+  "StringField": "hello",
+  "Field3": 1084818905618843912,
   "Field4": {
-   "SecondField1": 6
-  }
+   "SecondField1": 10
+  },
+  "OffsetOfField3": 7,
+  "SizeOfField3": 8,
+  "OffsetOfField2": 6,
+  "RelOffsetField2": 4,
+  "SizeOfField2": 5,
+  "StructOffset": 2,
+  "StringFieldSize": 12
  },
- "Field3": 578437695752307201,
+ "Field3": 1084818905618843912,
  "Field4": {
-  "SecondField1": 6
- }
+  "SecondField1": 10
+ },
+ "OffsetOfField3": 7,
+ "SizeOfField3": 8,
+ "OffsetOfField2": 6,
+ "RelOffsetField2": 4,
+ "SizeOfField2": 5,
+ "StructOffset": 2,
+ "StringFieldSize": 12
 }

--- a/parser.go
+++ b/parser.go
@@ -17,8 +17,15 @@ type Parser interface {
 	New(profile *Profile, options *ordereddict.Dict) (Parser, error)
 }
 
+// Used by parsers or wrappers who have fixed size
 type Sizer interface {
 	Size() int
+}
+
+// Applies on a parser which needs to instantiate to figure out the
+// size. i.e. the size depends on the data read (e.g. a string).
+type InstanceSizer interface {
+	InstanceSize(scope vfilter.Scope, reader io.ReaderAt, offset int64) int
 }
 
 // Allows psuedo elements to reveal their own value.

--- a/reference.go
+++ b/reference.go
@@ -1,0 +1,46 @@
+package vtypes
+
+import (
+	"encoding/json"
+	"io"
+
+	"www.velocidex.com/golang/vfilter"
+)
+
+// A reference is a wrapper around a struct member which can contain
+// metadata about it.
+
+type StructFieldReference struct {
+	// Offset to the start of the struct
+	offset int64
+	reader io.ReaderAt
+	scope  vfilter.Scope
+	field  string
+
+	parser *ParseAtOffset
+}
+
+// The offset within the struct
+func (self *StructFieldReference) RelOffset() int64 {
+	return self.parser.getOffset(self.scope)
+}
+
+func (self *StructFieldReference) Start() int64 {
+	return self.offset + self.parser.getOffset(self.scope)
+}
+
+func (self *StructFieldReference) Size() int {
+	return self.parser.Size(self.scope, self.reader, self.offset)
+}
+
+func (self *StructFieldReference) End() int64 {
+	return self.Start() + int64(self.Size())
+}
+
+func (self *StructFieldReference) Value() interface{} {
+	return self.parser.Parse(self.scope, self.reader, self.offset)
+}
+
+func (self *StructFieldReference) MarshalJSON() ([]byte, error) {
+	return json.Marshal(self.Value())
+}

--- a/scope.go
+++ b/scope.go
@@ -4,9 +4,7 @@ import "www.velocidex.com/golang/vfilter"
 
 func MakeScope() vfilter.Scope {
 	result := vfilter.NewScope()
-	result.AddProtocolImpl(
-		&StructAssociative{}, &ArrayAssociative{}, &ArrayIterator{},
-	)
+	result.AddProtocolImpl(GetProtocols()...)
 
 	return result
 }

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package vtypes
 
 import (
 	"context"
+	"io"
 	"reflect"
 	"strings"
 
@@ -66,9 +67,26 @@ func to_int64(x interface{}) (int64, bool) {
 // Some helpers
 
 func SizeOf(obj interface{}) int {
-	sizer, ok := obj.(Sizer)
-	if ok {
-		return sizer.Size()
+	switch t := obj.(type) {
+	case Sizer:
+		return t.Size()
+
+		// Built in types
+	case string:
+		return len(t)
+	case []byte:
+		return len(t)
+	default:
+		return 0
+	}
+}
+
+func InstanceSizeOf(parser Parser,
+	scope vfilter.Scope, reader io.ReaderAt, offset int64) int {
+
+	switch t := parser.(type) {
+	case InstanceSizer:
+		return t.InstanceSize(scope, reader, offset)
 	}
 	return 0
 }


### PR DESCRIPTION
This makes it possible to get metadata on struct fields which are basic types like integers or strings.

It is now very simple to position a field immediately after another field, without needing to know the offset exactly.

```json
[
  ["TestStruct", 0, [
     ["Field1", 2, "uint8"],
     ["Next", "x=>x.`@Field1`.RelEndOf", "uint16"],
  ]]
]
```